### PR TITLE
Simplified testing regex

### DIFF
--- a/tools/testing/selftests/devices/error_logs/test_device_error_logs.py
+++ b/tools/testing/selftests/devices/error_logs/test_device_error_logs.py
@@ -25,7 +25,7 @@ import ksft
 kmsg = "/dev/kmsg"
 
 RE_log = re.compile(
-    r"((?P<prefix>[0-9]+),){3}(?P<flag>([^;]|,)*);(?P<message>.*)"
+    r"((\d+),){3}((?iLmsux)|([^;]|,)+);(.*)"
 )
 RE_tag = re.compile(r" (?P<key>[^=]+)=(?P<value>.*)")
 

--- a/tools/testing/selftests/devices/error_logs/test_device_error_logs.py
+++ b/tools/testing/selftests/devices/error_logs/test_device_error_logs.py
@@ -25,7 +25,7 @@ import ksft
 kmsg = "/dev/kmsg"
 
 RE_log = re.compile(
-    r"(?P<prefix>[0-9]+),(?P<sequence>[0-9]+),(?P<timestamp>[0-9]+),(?P<flag>[^;]*)(,[^;]*)*;(?P<message>.*)"
+    r"((?P<prefix>[0-9]+),){3}(?P<flag>([^;]|,)*);(?P<message>.*)"
 )
 RE_tag = re.compile(r" (?P<key>[^=]+)=(?P<value>.*)")
 


### PR DESCRIPTION
This PR solves Code Scanning Alert #58 by simplifying the testing regex used to analyze messages coming from kernel drivers.