### PR TITLE
Potential fix for code scanning alert no. 77: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,6 +5,8 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run Build Wrapper
         run: |
           make defconfig
-          build-wrapper-linux-x86-64 --out-dir $HOME/build make -j$(nproc)
+          build-wrapper-linux-x86-64 --out-dir build make -j$(nproc)
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
@@ -39,4 +39,4 @@ jobs:
           args: >
             -Dsonar.projectKey=marck283_linux
             -Dsonar.organization=marck283
-            -Dsonar.cfamily.build-wrapper-output=$HOME/build
+            -Dsonar.cfamily.build-wrapper-output=build

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -35,8 +35,10 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_SCANNER_OPTS: -Xmx4096m -XX:+UseG1GC
         with:
           args: >
             -Dsonar.projectKey=marck283_linux
             -Dsonar.organization=marck283
             -Dsonar.cfamily.build-wrapper-output=build
+            -Dsonar.sources=arch


### PR DESCRIPTION
Potential fix for [https://github.com/marck283/linux/security/code-scanning/77](https://github.com/marck283/linux/security/code-scanning/77)

Add an explicit `permissions` block to `.github/workflows/sonarqube.yml` at the workflow root so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the best minimal safe setting is:

- `contents: read`

This supports `actions/checkout` and avoids unnecessary write permissions.  
Change location: directly under the `on:` trigger block (before `jobs:`) or near the top-level keys.

No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
